### PR TITLE
해시태그 검색 기능 구현

### DIFF
--- a/project-board/src/main/java/com/tw/projectboard/controller/ArticleController.java
+++ b/project-board/src/main/java/com/tw/projectboard/controller/ArticleController.java
@@ -51,4 +51,20 @@ public class ArticleController {
         return "articles/detail";
     }
 
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+            @RequestParam(required = false, name = "searchValue") String searchValue,
+            @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+            ModelMap map){
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+        map.addAttribute("articles", articles);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
+        return "articles/search-hashtag";
+    }
+
 }

--- a/project-board/src/main/java/com/tw/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/tw/projectboard/repository/ArticleRepository.java
@@ -4,6 +4,7 @@ import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.tw.projectboard.domain.Article;
 import com.tw.projectboard.domain.QArticle;
+import com.tw.projectboard.repository.querydsl.ArticleRepositoryCustom;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -15,6 +16,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>, //얘는 완전 일치 검색만 가능
         QuerydslBinderCustomizer<QArticle>
 {

--- a/project-board/src/main/java/com/tw/projectboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/project-board/src/main/java/com/tw/projectboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,7 @@
+package com.tw.projectboard.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+    List<String> findAllDistinctHashtags();
+}

--- a/project-board/src/main/java/com/tw/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/project-board/src/main/java/com/tw/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,26 @@
+package com.tw.projectboard.repository.querydsl;
+
+import com.tw.projectboard.domain.Article;
+import com.tw.projectboard.domain.QArticle;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+
+        QArticle article = QArticle.article;
+
+        return from(article)
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull())
+                .fetch();
+    }
+}

--- a/project-board/src/main/java/com/tw/projectboard/service/ArticleService.java
+++ b/project-board/src/main/java/com/tw/projectboard/service/ArticleService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 
 @Slf4j
 @RequiredArgsConstructor
@@ -68,5 +70,18 @@ public class ArticleService {
 
     public long getArticleCount() {
         return articleRepository.count();
+    }
+
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        if (hashtag == null || hashtag.isBlank()){
+            return Page.empty(pageable);
+        }
+
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtags();
     }
 }

--- a/project-board/src/main/resources/templates/articles/search-hashtag.html
+++ b/project-board/src/main/resources/templates/articles/search-hashtag.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="description" content="">
+    <meta name="author" content="Uno Kim">
+    <title>해시태그 검색</title>
+
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+    <link href="/css/articles/table-header.css" rel="stylesheet">
+</head>
+
+<body>
+<header id="header">
+    헤더 삽입부
+    <hr>
+</header>
+
+<main class="container">
+    <header class="py-5 text-center">
+        <h1>Hashtags</h1>
+    </header>
+
+    <section class="row">
+        <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+            <div class="p-2">
+                <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+            </div>
+        </div>
+    </section>
+
+    <hr>
+
+    <table class="table" id="article-table">
+        <thead>
+        <tr>
+            <th class="title col-6"><a>제목</a></th>
+            <th class="content col-4"><a>본문</a></th>
+            <th class="user-id"><a>작성자</a></th>
+            <th class="created-at"><a>작성일</a></th>
+        </tr>
+        </thead>
+        <tbody>
+        <tr>
+            <td class="title"><a>첫글</a></td>
+            <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+            <td class="user-id">Uno</td>
+            <td class="created-at"><time>2022-01-01</time></td>
+        </tr>
+        <tr>
+            <td>두번째글</td>
+            <td>본문</td>
+            <td>Uno</td>
+            <td><time>2022-01-02</time></td>
+        </tr>
+        <tr>
+            <td>세번째글</td>
+            <td>본문</td>
+            <td>Uno</td>
+            <td><time>2022-01-03</time></td>
+        </tr>
+        </tbody>
+    </table>
+
+    <nav id="pagination" aria-label="Page navigation">
+        <ul class="pagination justify-content-center">
+            <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+            <li class="page-item"><a class="page-link" href="#">1</a></li>
+            <li class="page-item"><a class="page-link" href="#">Next</a></li>
+        </ul>
+    </nav>
+
+</main>
+
+<footer id="footer">
+    <hr>
+    푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/project-board/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/project-board/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,74 @@
+<?xml version="1.0"?>
+<thlogic>
+    <attr sel="#header" th:replace="header :: header" />
+    <attr sel="#footer" th:replace="footer :: footer" />
+    <attr sel="main" th:object="${articles}">
+        <attr sel="#hashtags" th:remove="all-but-first">
+            <attr sel="div" th:each="hashtag : ${hashtags}">
+                <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+            page=${param.page},
+            sort=${param.sort},
+            searchType=${searchType.name},
+            searchValue=${hashtag}
+        )}" />
+            </attr>
+        </attr>
+        <attr sel="#article-table">
+            <attr sel="thead/tr">
+                <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.content/a" th:text="'본문'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+                <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+            </attr>
+            <attr sel="tbody" th:remove="all-but-first">
+                <attr sel="tr[0]" th:each="article : ${articles}">
+                    <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+                    <attr sel="td.content/span" th:text="${article.content}" />
+                    <attr sel="td.user-id" th:text="${article.nickname}" />
+                    <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+                </attr>
+            </attr>
+        </attr>
+        <attr sel="#pagination">
+            <attr sel="ul">
+                <attr sel="li[0]/a"
+                      th:text="'previous'"
+                      th:href="@{/articles(page=${articles.number - 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+                />
+                <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+                    <attr sel="a"
+                          th:text="${pageNumber + 1}"
+                          th:href="@{/articles(page=${pageNumber}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                          th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+                    />
+                </attr>
+                <attr sel="li[2]/a"
+                      th:text="'next'"
+                      th:href="@{/articles(page=${articles.number + 1}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                      th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+                />
+            </attr>
+        </attr>
+    </attr>
+</thlogic>

--- a/project-board/src/test/java/com/tw/projectboard/controller/ArticleControllerTest.java
+++ b/project-board/src/test/java/com/tw/projectboard/controller/ArticleControllerTest.java
@@ -6,7 +6,6 @@ import com.tw.projectboard.dto.ArticleWithCommentsDto;
 import com.tw.projectboard.dto.UserAccountDto;
 import com.tw.projectboard.service.ArticleService;
 import com.tw.projectboard.service.PaginationService;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -133,30 +132,43 @@ class ArticleControllerTest {
         then(paginationService).should().getPaginationBarNumbers(pageable.getPageNumber(), Page.empty().getTotalPages());
     }
 
-    @Disabled("구현 중")
-    @DisplayName("[view][GET] 게시글 검색 전용 페이지 - 정상 호출")
-    @Test
-    void givenNothing_whenRequestingArticlesSearchView_thenReturnArticlesSearchView() throws Exception {
-        //given
-
-        //when&then
-        mvc.perform(get("/articles/search"))
-                .andExpect(status().isOk())
-                .andExpect(view().name("articles/search"))
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
-    }
-
-    @Disabled("구현 중")
     @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출")
     @Test
-    void givenNothing_whenRequestingArticleHashtagSearchView_thenReturnArticleHashtagSearchView() throws Exception {
+    void givenNothing_whenRequestingArticleSearchHashtagView_thenReturnArticleSearchHashtagView() throws Exception {
         //given
+        given(articleService.searchArticlesViaHashtag(eq(null), any(Pageable.class))).willReturn(Page.empty());
 
         //when&then
         mvc.perform(get("/articles/search-hashtag"))
                 .andExpect(status().isOk())
                 .andExpect(view().name("articles/search-hashtag"))
-                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML));
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(model().attribute("articles", Page.empty()))
+                .andExpect(model().attributeExists("hashtags"))
+                .andExpect(model().attribute("searchType", SearchType.HASHTAG))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
+        then(articleService).should().searchArticlesViaHashtag(eq(null), any(Pageable.class));
+    }
+
+    @DisplayName("[view][GET] 게시글 해시태그 검색 페이지 - 정상 호출, 해시태그 검색")
+    @Test
+    void givenHashtag_whenRequestingArticleSearchHashtagView_thenReturnArticleSearchHashtagView() throws Exception {
+        //given
+        String hashtag = "#java";
+        given(articleService.searchArticlesViaHashtag(eq(hashtag), any(Pageable.class))).willReturn(Page.empty());
+
+        //when&then
+        mvc.perform(get("/articles/search-hashtag")
+                        .queryParam("searchValue", hashtag)
+                )
+                .andExpect(status().isOk())
+                .andExpect(view().name("articles/search-hashtag"))
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andExpect(model().attribute("articles", Page.empty()))
+                .andExpect(model().attributeExists("hashtags"))
+                .andExpect(model().attribute("searchType", SearchType.HASHTAG))
+                .andExpect(model().attributeExists("paginationBarNumbers"));
+        then(articleService).should().searchArticlesViaHashtag(eq(hashtag), any(Pageable.class));
     }
 
     private ArticleWithCommentsDto createArticleWithCommentsDto(){

--- a/project-board/src/test/java/com/tw/projectboard/service/ArticleServiceTest.java
+++ b/project-board/src/test/java/com/tw/projectboard/service/ArticleServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.*;
@@ -63,6 +64,38 @@ class ArticleServiceTest {
         assertThat(articles).isEmpty();
         then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);
     }
+
+    @DisplayName("검색어 없이 게시글을 해시태그 검색하면, 빈 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticlesViaHashtag_thenReturnsEmptyPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(null, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("게시글을 해시태그 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenHashtag_whenSearchingArticlesViaHashtag_thenReturnsArticlesPage() {
+        // Given
+        String hashtag = "#java";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByHashtag(hashtag, pageable)).willReturn(Page.empty(pageable));
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtag, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).should().findByHashtag(hashtag, pageable);
+    }
+
+
 
     @DisplayName("게시글을 조회하면, 게시글을 반환한다.")
     @Test
@@ -172,6 +205,22 @@ class ArticleServiceTest {
         //then
         assertThat(actual).isEqualTo(expected);
         then(articleRepository).should().count();
+    }
+
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsHashtags() {
+        //given
+        List<String> expectedHashtags = List.of("#java", "#spring", "#sing");
+        given(articleRepository.findAllDistinctHashtags()).willReturn(expectedHashtags);
+
+        //when
+        List<String> actualHashtags = sut.getHashtags();
+
+        //then
+        assertThat(actualHashtags).isEqualTo(expectedHashtags);
+        then(articleRepository).should().findAllDistinctHashtags();
+
     }
 
     private UserAccount createUserAccount() {


### PR DESCRIPTION
해시 태그 검색 기능 구현

- /articles/search-hashtag로 해시태그 검색 페이지 접근 가능
- 해시태그 리스트 나열
- 특정 해시태그를 눌러 해시태그 검색 가능
- 조회된 게시글 목록에는 해시태그는 빠지고 본문이 일정 길이만큼 미리보기로 보임